### PR TITLE
Fix frontend import errors and nodemon restart loop

### DIFF
--- a/src/components/ui/QuestionEditor.jsx
+++ b/src/components/ui/QuestionEditor.jsx
@@ -3,7 +3,7 @@ import Button from './Button';
 import Input from './Input';
 import Select from './Select';
 import Icon from '../AppIcon';
-import Checkbox from './Checkbox';
+import { Checkbox } from './Checkbox';
 
 const QuestionEditor = ({ isOpen, onClose, onSave, question, currentLanguage }) => {
   const [text, setText] = useState('');

--- a/src/pages/admin-dashboard/components/UnivariateAnalysisPanel.jsx
+++ b/src/pages/admin-dashboard/components/UnivariateAnalysisPanel.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import Input from '../../../components/ui/Input';
 import Button from '../../../components/ui/Button';
-import Checkbox from '../../../components/ui/Checkbox';
+import { Checkbox } from '../../../components/ui/Checkbox';
 import LoadingSpinner from '../../../components/ui/LoadingSpinner';
 import { useToast } from '../../../context/ToastContext';
 


### PR DESCRIPTION
This commit addresses several issues that were preventing the application from running correctly.

- **Corrected Checkbox Imports:** Fixed multiple components that were using a default import for the `Checkbox` component, which is a named export.
- **Fixed Python Syntax:** Corrected a line of Python syntax that was mistakenly present in a JSX file.
- **Fixed Nodemon Restart Loop:** Modified `nodemon.json` to stop the server from constantly restarting.
- **Cleaned up Frontend Components:** Removed duplicate and misplaced code from several React components.

The following files were modified:
- src/pages/admin-dashboard/components/ModelTrainingPanel.jsx
- src/pages/admin-dashboard/components/UnivariateAnalysisPanel.jsx
- src/components/ui/QuestionEditor.jsx
- server/nodemon.json
- and other frontend files that were cleaned up.