### PR TITLE
fix(server): Prevent crash on startup during installation

### DIFF
--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,24 +1,55 @@
 import { Sequelize } from 'sequelize';
 
-// Environment variables are loaded from the main server.js file
+let sequelize = null;
 
-// Create a new Sequelize instance
-const sequelize = new Sequelize(
-  process.env.DB_NAME,
-  process.env.DB_USER,
-  process.env.DB_PASSWORD,
-  {
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    dialect: process.env.DB_DIALECT,
-    logging: false, // Set to console.log to see executed SQL queries
+/**
+ * Initializes the Sequelize instance.
+ * This function should be called only once when the application is ready to connect to the database.
+ * @returns {Sequelize} The initialized sequelize instance.
+ */
+const initSequelize = () => {
+  if (sequelize) {
+    console.warn('Sequelize has already been initialized.');
+    return sequelize;
   }
-);
 
-// Function to test the database connection
+  // Environment variables must be loaded before calling this function.
+  sequelize = new Sequelize(
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PASSWORD,
+    {
+      host: process.env.DB_HOST,
+      port: process.env.DB_PORT,
+      dialect: process.env.DB_DIALECT,
+      logging: false, // Set to console.log to see executed SQL queries
+    }
+  );
+
+  return sequelize;
+};
+
+/**
+ * Retrieves the singleton Sequelize instance.
+ * Throws an error if Sequelize has not been initialized yet.
+ * @returns {Sequelize} The sequelize instance.
+ */
+const getSequelize = () => {
+  if (!sequelize) {
+    throw new Error('Sequelize has not been initialized. Call initSequelize() first.');
+  }
+  return sequelize;
+};
+
+/**
+ * Tests the database connection using the initialized Sequelize instance.
+ * Exits the process on failure.
+ */
 const connectDB = async () => {
   try {
-    await sequelize.authenticate();
+    // We get the instance here to ensure it's initialized.
+    const dbInstance = getSequelize();
+    await dbInstance.authenticate();
     console.log('MySQL Connection has been established successfully.');
   } catch (error) {
     console.error('Unable to connect to the database:', error);
@@ -26,6 +57,5 @@ const connectDB = async () => {
   }
 };
 
-// Export the sequelize instance for model definitions and the connect function
-export { connectDB };
-export default sequelize;
+// Export the functions to control the lifecycle of the Sequelize instance.
+export { initSequelize, getSequelize, connectDB };

--- a/server/models/Assessment.js
+++ b/server/models/Assessment.js
@@ -1,46 +1,47 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+const createAssessmentModel = (sequelize, DataTypes) => {
+  const Assessment = sequelize.define('Assessment', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    // Foreign key for the User model (the patient)
+    patientId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users', // Note: Sequelize defaults to plural table names
+        key: 'id',
+      }
+    },
+    // Foreign key for the Questionnaire model
+    questionnaireId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Questionnaires',
+        key: 'id',
+      }
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'in-progress', 'completed'),
+      defaultValue: 'pending',
+    },
+    // Storing array of response objects as JSON.
+    // A better long-term solution is a separate 'Responses' table.
+    responses: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    riskScore: {
+      type: DataTypes.FLOAT,
+      allowNull: true,
+    },
+  }, {
+    timestamps: true,
+  });
 
-const Assessment = sequelize.define('Assessment', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  // Foreign key for the User model (the patient)
-  patientId: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    references: {
-      model: 'Users', // Note: Sequelize defaults to plural table names
-      key: 'id',
-    }
-  },
-  // Foreign key for the Questionnaire model
-  questionnaireId: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    references: {
-      model: 'Questionnaires',
-      key: 'id',
-    }
-  },
-  status: {
-    type: DataTypes.ENUM('pending', 'in-progress', 'completed'),
-    defaultValue: 'pending',
-  },
-  // Storing array of response objects as JSON.
-  // A better long-term solution is a separate 'Responses' table.
-  responses: {
-    type: DataTypes.JSON,
-    allowNull: true,
-  },
-  riskScore: {
-    type: DataTypes.FLOAT,
-    allowNull: true,
-  },
-}, {
-  timestamps: true,
-});
+  return Assessment;
+};
 
-export default Assessment;
+export default createAssessmentModel;

--- a/server/models/FeatureFlag.js
+++ b/server/models/FeatureFlag.js
@@ -1,11 +1,11 @@
+const createFeatureFlagModel = (sequelize, DataTypes) => {
+  const FeatureFlag = sequelize.define('FeatureFlag', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    key: { type: DataTypes.STRING, unique: true },
+    value: { type: DataTypes.STRING },
+  }, { timestamps: true });
 
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+  return FeatureFlag;
+};
 
-const FeatureFlag = sequelize.define('FeatureFlag', {
-  id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-  key: { type: DataTypes.STRING, unique: true },
-  value: { type: DataTypes.STRING },
-}, { timestamps: true });
-
-export default FeatureFlag;
+export default createFeatureFlagModel;

--- a/server/models/Note.js
+++ b/server/models/Note.js
@@ -1,36 +1,37 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
-
-const Note = sequelize.define('Note', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  // Foreign key for the User this note is about (the patient)
-  patientId: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    references: {
-      model: 'Users',
-      key: 'id',
+const createNoteModel = (sequelize, DataTypes) => {
+  const Note = sequelize.define('Note', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
     },
-  },
-  // Foreign key for the User who wrote the note (the author)
-  authorId: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    references: {
-      model: 'Users',
-      key: 'id',
+    // Foreign key for the User this note is about (the patient)
+    patientId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
     },
-  },
-  text: {
-    type: DataTypes.TEXT, // TEXT is more suitable for long content
-    allowNull: false,
-  },
-}, {
-  timestamps: true,
-});
+    // Foreign key for the User who wrote the note (the author)
+    authorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
+    },
+    text: {
+      type: DataTypes.TEXT, // TEXT is more suitable for long content
+      allowNull: false,
+    },
+  }, {
+    timestamps: true,
+  });
 
-export default Note;
+  return Note;
+};
+
+export default createNoteModel;

--- a/server/models/PredictionModel.js
+++ b/server/models/PredictionModel.js
@@ -1,36 +1,37 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+const createPredictionModel = (sequelize, DataTypes) => {
+  const PredictionModel = sequelize.define('PredictionModel', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'pending', // e.g., pending, training, completed, failed
+    },
+    performance: {
+      type: DataTypes.JSON,
+      allowNull: true, // Performance metrics might not exist if training fails
+    },
+    modelData: {
+      type: DataTypes.BLOB('long'), // Use BLOB for binary data, 'long' for larger models
+      allowNull: true,
+    },
+    parameters: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    }
+  }, {
+    timestamps: true,
+  });
 
-const PredictionModel = sequelize.define('PredictionModel', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  name: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    unique: true,
-  },
-  status: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    defaultValue: 'pending', // e.g., pending, training, completed, failed
-  },
-  performance: {
-    type: DataTypes.JSON,
-    allowNull: true, // Performance metrics might not exist if training fails
-  },
-  modelData: {
-    type: DataTypes.BLOB('long'), // Use BLOB for binary data, 'long' for larger models
-    allowNull: true,
-  },
-  parameters: {
-    type: DataTypes.JSON,
-    allowNull: true,
-  }
-}, {
-  timestamps: true,
-});
+  return PredictionModel;
+};
 
-export default PredictionModel;
+export default createPredictionModel;

--- a/server/models/Question.js
+++ b/server/models/Question.js
@@ -1,51 +1,52 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+const createQuestionModel = (sequelize, DataTypes) => {
+  const Question = sequelize.define('Question', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    text: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    questionType: {
+      type: DataTypes.ENUM('text', 'paragraph', 'multiple-choice', 'checkboxes', 'dropdown', 'date', 'datetime', 'linear-scale'),
+      allowNull: false,
+      defaultValue: 'text',
+    },
+    // Storing options as JSON. Complex validation (e.g., required for certain types)
+    // must be handled at the application/controller level.
+    options: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    isRequired: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    // Scale fields are nullable because they are only required for 'linear-scale' type.
+    // This logic must be enforced in the application layer.
+    minScale: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    maxScale: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    minLabel: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    maxLabel: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  }, {
+    timestamps: true,
+  });
 
-const Question = sequelize.define('Question', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  text: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  questionType: {
-    type: DataTypes.ENUM('text', 'paragraph', 'multiple-choice', 'checkboxes', 'dropdown', 'date', 'datetime', 'linear-scale'),
-    allowNull: false,
-    defaultValue: 'text',
-  },
-  // Storing options as JSON. Complex validation (e.g., required for certain types)
-  // must be handled at the application/controller level.
-  options: {
-    type: DataTypes.JSON,
-    allowNull: true,
-  },
-  isRequired: {
-    type: DataTypes.BOOLEAN,
-    defaultValue: false,
-  },
-  // Scale fields are nullable because they are only required for 'linear-scale' type.
-  // This logic must be enforced in the application layer.
-  minScale: {
-    type: DataTypes.INTEGER,
-    allowNull: true,
-  },
-  maxScale: {
-    type: DataTypes.INTEGER,
-    allowNull: true,
-  },
-  minLabel: {
-    type: DataTypes.STRING,
-    allowNull: true,
-  },
-  maxLabel: {
-    type: DataTypes.STRING,
-    allowNull: true,
-  },
-}, {
-  timestamps: true,
-});
+  return Question;
+};
 
-export default Question;
+export default createQuestionModel;

--- a/server/models/Questionnaire.js
+++ b/server/models/Questionnaire.js
@@ -1,22 +1,23 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+const createQuestionnaireModel = (sequelize, DataTypes) => {
+  const Questionnaire = sequelize.define('Questionnaire', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: true, // Assuming description can be optional
+    },
+  }, {
+    timestamps: true, // This will add createdAt and updatedAt fields
+  });
 
-const Questionnaire = sequelize.define('Questionnaire', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  title: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  description: {
-    type: DataTypes.STRING,
-    allowNull: true, // Assuming description can be optional
-  },
-}, {
-  timestamps: true, // This will add createdAt and updatedAt fields
-});
+  return Questionnaire;
+};
 
-export default Questionnaire;
+export default createQuestionnaireModel;

--- a/server/models/Setting.js
+++ b/server/models/Setting.js
@@ -1,29 +1,30 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../config/db.js';
+const createSettingModel = (sequelize, DataTypes) => {
+  const Setting = sequelize.define('Setting', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    key: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    // Using JSON type to accommodate various structures for settings,
+    // similar to Mongoose's 'Mixed' type.
+    value: {
+      type: DataTypes.JSON,
+      allowNull: false,
+    },
+  }, {
+    timestamps: true,
+  });
 
-const Setting = sequelize.define('Setting', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  key: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    unique: true,
-  },
-  // Using JSON type to accommodate various structures for settings,
-  // similar to Mongoose's 'Mixed' type.
-  value: {
-    type: DataTypes.JSON,
-    allowNull: false,
-  },
-}, {
-  timestamps: true,
-});
+  // Note: The original static method 'seedInitialSettings' should be
+  // re-implemented as a separate seeding script or function that runs
+  // after the database models are synchronized.
 
-// Note: The original static method 'seedInitialSettings' should be
-// re-implemented as a separate seeding script or function that runs
-// after the database models are synchronized.
+  return Setting;
+};
 
-export default Setting;
+export default createSettingModel;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,65 +1,67 @@
-import { DataTypes } from 'sequelize';
 import bcrypt from 'bcryptjs';
-import sequelize from '../config/db.js';
 
-const User = sequelize.define('User', {
-  id: {
-    type: DataTypes.INTEGER,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  firstName: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  lastName: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  email: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    unique: true,
-    validate: {
-      isEmail: true,
+const createUserModel = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
     },
-  },
-  password: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  role: {
-    type: DataTypes.ENUM('patient', 'admin', 'researcher'),
-    defaultValue: 'patient',
-    allowNull: false,
-  },
-  name: {
-    type: DataTypes.VIRTUAL,
-    get() {
-      return `${this.firstName} ${this.lastName}`;
+    firstName: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
-  }
-}, {
-  timestamps: true,
-  hooks: {
-    beforeCreate: async (user) => {
-      if (user.password) {
-        const salt = await bcrypt.genSalt(10);
-        user.password = await bcrypt.hash(user.password, salt);
-      }
+    lastName: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
-    beforeUpdate: async (user) => {
-      if (user.changed('password')) {
-        const salt = await bcrypt.genSalt(10);
-        user.password = await bcrypt.hash(user.password, salt);
-      }
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true,
+      },
     },
-  },
-});
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    role: {
+      type: DataTypes.ENUM('patient', 'admin', 'researcher'),
+      defaultValue: 'patient',
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        return `${this.firstName} ${this.lastName}`;
+      },
+    }
+  }, {
+    timestamps: true,
+    hooks: {
+      beforeCreate: async (user) => {
+        if (user.password) {
+          const salt = await bcrypt.genSalt(10);
+          user.password = await bcrypt.hash(user.password, salt);
+        }
+      },
+      beforeUpdate: async (user) => {
+        if (user.changed('password')) {
+          const salt = await bcrypt.genSalt(10);
+          user.password = await bcrypt.hash(user.password, salt);
+        }
+      },
+    },
+  });
 
-// Instance method to compare passwords
-User.prototype.matchPassword = async function(enteredPassword) {
-  return await bcrypt.compare(enteredPassword, this.password);
+  // Instance method to compare passwords
+  User.prototype.matchPassword = async function(enteredPassword) {
+    return await bcrypt.compare(enteredPassword, this.password);
+  };
+
+  return User;
 };
 
-export default User;
+export default createUserModel;

--- a/server/routes/installer.js
+++ b/server/routes/installer.js
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { Sequelize } from 'sequelize';
 import initializeDB from '../models/index.js';
+import { initSequelize } from '../config/db.js';
 
 const router = express.Router();
 
@@ -88,8 +89,12 @@ router.post('/create-admin', async (req, res) => {
   }
 
   try {
-    // Initialize the database and get the models
-    const db = await initializeDB();
+    // Since the server has been restarted, we can now initialize the database
+    // with the settings from the newly created .env file.
+    initSequelize();
+
+    // Initialize the models and their associations
+    const db = initializeDB();
     const { User, sequelize } = db;
 
     // 1. Sync database tables to ensure they exist

--- a/server/server.js
+++ b/server/server.js
@@ -23,8 +23,10 @@ async function main() {
         }
     }
 
-    // --- 4. Initialize Database Connection ---
-    const { connectDB, default: sequelize } = await import('./config/db.js');
+    // --- 4. Load Database and Model Initializers ---
+    // We import the functions but DO NOT initialize the connection yet.
+    const { initSequelize, connectDB } = await import('./config/db.js');
+    const initializeDB = (await import('./models/index.js')).default;
 
     // --- 5. Initialize Express App ---
     const app = express();
@@ -49,8 +51,18 @@ async function main() {
     } else {
         try {
             console.log('Application is installed. Starting main server...');
+
+            // 1. Initialize Sequelize with env variables
+            initSequelize();
+
+            // 2. Initialize models and associations
+            const db = initializeDB();
+
+            // 3. Connect to the database
             await connectDB();
-            await sequelize.sync();
+
+            // 4. Sync database schema
+            await db.sequelize.sync();
             console.log('Database synchronized.');
 
             // Dynamically import and mount main routes


### PR DESCRIPTION
The server was previously attempting to initialize the Sequelize database connection immediately on application startup. This caused a 500 Internal Server Error if the application was not yet installed, as no .env file with database credentials existed.

This commit refactors the database and model initialization to use a lazy-loading pattern:
- The main Sequelize instance is now created on-demand via an `initSequelize` function, not on module import.
- All Sequelize models have been refactored to export a factory function that accepts a sequelize instance.
- The server startup logic now only initializes the database connection if it detects that the installation is complete (via `installer.lock`).
- The installer's `create-admin` route now correctly initializes the database after the user has been guided through a manual server restart.

This resolves the startup crash and ensures a robust installation process.