### PR TITLE
fix(installer): Resolve server crash and proxy connection errors

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -19,7 +19,7 @@ export default defineConfig({
     allowedHosts: ['.amazonaws.com', '.builtwithrocket.new'],
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://127.0.0.1:3001',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
This commit addresses two critical issues that prevented the application installer from functioning correctly.

The first issue was a server crash on startup when the application was not yet installed. The server would attempt to initialize the Sequelize database connection immediately on module import, which failed because no .env file with database credentials existed. This was resolved by refactoring the database and model initialization to use a lazy-loading pattern. The connection is now only attempted after the installer has run and the server has been restarted.

The second issue, which appeared after the server was stabilized, was an EACCES proxy error from Vite. This was likely caused by an ambiguous use of 'localhost' in the proxy target. This was resolved by changing the target to the explicit IP address '127.0.0.1'.

Together, these changes ensure a robust and functional installation process.