### PR TITLE
fix: Resolve installer connection and file path errors

### DIFF
--- a/server/routes/installer.js
+++ b/server/routes/installer.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { Sequelize } from 'sequelize';
 import initializeDB from '../models/index.js';
 
@@ -8,9 +9,11 @@ const router = express.Router();
 
 // Helper function to get the path to the .env file in the server directory
 const getEnvPath = () => {
-  // Using __dirname requires a different setup in ES Modules, so we construct the path manually
-  const currentFilePath = new URL(import.meta.url).pathname;
-  return path.join(path.dirname(currentFilePath), '..', '.env');
+  // Use fileURLToPath to ensure correct path conversion on all platforms, especially Windows
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  // Navigate up from /routes to /server to find the target .env path
+  return path.join(__dirname, '..', '.env');
 };
 
 // @desc    Test MySQL database connection


### PR DESCRIPTION
This commit addresses two critical bugs that prevented the application installer from completing successfully.

1.  **fix(vite): Align proxy port with backend server port** The Vite development server was configured to proxy API requests to a hardcoded backend port of 3001. The user's environment runs the backend on port 5000, which caused a connection refused (ECONNREFUSED) error. The Vite config is now updated to proxy to the correct port (5000).

2.  **fix(server): Correct .env file path generation on Windows** The installer was failing to write the `.env` file on Windows due to an incorrect path construction that created an invalid path (e.g., `C:\C:\...`). This has been fixed by using Node's `fileURLToPath` utility to ensure cross-platform compatibility.