### PR TITLE
fix(server): Correct port number written by installer

### DIFF
--- a/server/routes/installer.js
+++ b/server/routes/installer.js
@@ -58,7 +58,7 @@ router.post('/write-config', async (req, res) => {
 
   const envContent = `
 # Server Configuration
-PORT=3001
+PORT=5000
 JWT_SECRET=${jwtSecret}
 ADMIN_RESTART_TOKEN=dev-restart-key
 


### PR DESCRIPTION
The installer route in `server/routes/installer.js` was hardcoding `PORT=3001` into the `.env` file it generates. This caused the backend to start on the wrong port after installation, breaking the communication with the frontend proxy which is configured for port 5000.

This commit changes the hardcoded value to `5000`, ensuring that after a successful installation, the server will restart on the correct port and the application will be functional.